### PR TITLE
Changes to build from modified source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,19 +2,22 @@
 # Makefile for openchain
 #
 NAME = openchain-core
-OUTDIR = ../../../openchain-core
+TOPDIR = ../../../..
+OUTDIR = $(TOPDIR)/openchain-core
 HN = `hostname`
 
+OPENCHAIN_RELEASE=v0.6.2
+
+# default target does nothing so the snapcraft make plugin can do "make && make install" and not fail
 default:
 
 
-install: 
-	mkdir -p $(OUTDIR)/data
-	wget -O project.json https://raw.githubusercontent.com/openchain/openchain/v0.6.2/src/Openchain/project.json 
-	wget -O Program.cs https://raw.githubusercontent.com/openchain/openchain/v0.6.2/src/Openchain/Program.cs
-	wget -O $(OUTDIR)/data/config.json https://raw.githubusercontent.com/openchain/openchain/v0.6.2/src/Openchain/data/config.json
-	sed -e "s|ledger.db|/var/snap/openchain/curent/ledger.db|g" $(OUTDIR)/data/config.json > $(OUTDIR)/data/config.json.tmp
-	mv $(OUTDIR)/data/config.json.tmp $(OUTDIR)/data/config.json
-	sed -e "s|anchors.db|/var/snap/openchain/current/anchors.db|g" $(OUTDIR)/data/config.json > $(OUTDIR)/data/config.json.tmp
-	mv $(OUTDIR)/data/config.json.tmp $(OUTDIR)/data/config.json
-	dotnet restore && dotnet publish -o $(OUTDIR)
+install:
+	# Use modified source to adjust contentRootPath of .net app to a writeable location for the snapped executable
+	git clone https://github.com/mikemccracken/openchain openchain-src
+	# git clone https://github.com/openchain/openchain openchain-src
+	# cd openchain-src && git checkout $(OPENCHAIN_RELEASE) -b $(OPENCHAIN_RELEASE)
+
+	cd openchain-src && dotnet restore src/**/project.json && dotnet build src/Openchain && dotnet publish src/Openchain -o $(OUTDIR)
+	cd openchain-src && mkdir -p $(OUTDIR)/data
+	cd openchain-src && cp src/Openchain/data/config.json $(OUTDIR)/data

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,8 @@
 # Makefile for openchain
 #
 NAME = openchain-core
-TOPDIR = ../../../..
+TOPDIR = ../../../
 OUTDIR = $(TOPDIR)/openchain-core
-HN = `hostname`
 
 OPENCHAIN_RELEASE=v0.6.2
 

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,11 @@
 # Makefile for openchain
 #
 NAME = openchain-core
-TOPDIR = ../../../
+TOPDIR = ../../../..
 OUTDIR = $(TOPDIR)/openchain-core
 
 OPENCHAIN_RELEASE=v0.6.2
 
-# default target does nothing so the snapcraft make plugin can do "make && make install" and not fail
 default:
 
 

--- a/openchain
+++ b/openchain
@@ -1,6 +1,9 @@
 #!/bin/bash
 
 DLL_PATH="usr/share/dotnet/openchain-core"
-DLL="build.dll"
+DLL="Openchain.dll"
+
+mkdir -p ${SNAP_USER_DATA}/data
+[ -e ${SNAP_USER_DATA}/data/config.json ] || cp ${SNAP}/${DLL_PATH}/data/config.json ${SNAP_USER_DATA}/data/config.json
 
 cd $SNAP/${DLL_PATH} && dotnet ${DLL}


### PR DESCRIPTION
Builds openchain from source that was modified to set app root to
$SNAP_USER_DATA because it needs to be writeable.

Also copies config.json to that writeable location.

Signed-off-by: Michael McCracken mike.mccracken@canonical.com
